### PR TITLE
Show the configured url (if any) in the repo selection gui

### DIFF
--- a/src/main/java/com/smartbear/readyapi/plugin/git/ReadyApiGitIntegration.java
+++ b/src/main/java/com/smartbear/readyapi/plugin/git/ReadyApiGitIntegration.java
@@ -196,7 +196,7 @@ public class ReadyApiGitIntegration implements VcsIntegration {
         Iterator files = directoryStream.iterator();
         while (files.hasNext()) {
             Path path = (Path) files.next();
-            if (!path.toFile().isDirectory()){ // If there is any file other than only empty dirs then this is not an empty dir
+            if (!path.toFile().isDirectory()) { // If there is any file other than only empty dirs then this is not an empty dir
                 directoryStream.close();
                 return false;
             }
@@ -239,7 +239,7 @@ public class ReadyApiGitIntegration implements VcsIntegration {
         list.add(MergeStrategy.THEIRS.getName());
 
         String strategy = UISupport.prompt("Pulling changes from the remote repository may result in conflicts.\n" +
-                "Please select which merge strategy to use to resolve any such conflicts.\n",
+                        "Please select which merge strategy to use to resolve any such conflicts.\n",
                 "Select Merge Strategy",
                 list.toArray(new String[list.size()]),
                 MergeStrategy.OURS.getName());
@@ -503,5 +503,13 @@ public class ReadyApiGitIntegration implements VcsIntegration {
 
     public void cloneRepository(String repositoryPath, CredentialsProvider credentialsProvider, File emptyDirectory) throws GitAPIException {
         Git.cloneRepository().setURI(repositoryPath).setCredentialsProvider(credentialsProvider).setDirectory(emptyDirectory).call();
+    }
+
+    public String getRemoteRepositoryUrl(WsdlProject project) {
+        try {
+            return createGitObject(project.getPath()).getRepository().getConfig().getString("remote", "origin", "url");
+        } catch (Exception ignore) {
+            return null;
+        }
     }
 }

--- a/src/main/java/com/smartbear/readyapi/plugin/git/ui/AbstractRepositorySelectionGui.java
+++ b/src/main/java/com/smartbear/readyapi/plugin/git/ui/AbstractRepositorySelectionGui.java
@@ -23,8 +23,12 @@ public abstract class AbstractRepositorySelectionGui {
 
     private RepositoryForm selected;
 
-    protected Component createGui(String helpUrl, String helpText) {
+    protected Component createGui(String helpUrl, String helpText, String remoteRepositoryUrl) {
         JPanel panel = new JPanel(new MigLayout("wrap", "8[grow,fill]8", "8[][][grow,fill][]8"));
+
+        boolean httpUrl = isHttpUrl(remoteRepositoryUrl);
+        sshRepositoryForm = new SshRepositoryForm(httpUrl ? null : remoteRepositoryUrl, false);
+        httpsRepositoryForm = new HttpsRepositoryForm(httpUrl ? remoteRepositoryUrl : null, false);
 
         ButtonGroup group = new ButtonGroup();
 
@@ -36,8 +40,12 @@ public abstract class AbstractRepositorySelectionGui {
 
         panel.add(cards);
         panel.add(createLabelLink(helpUrl, helpText));
-        selectCard(LABEL_SSH);
+        selectCard(httpUrl ? LABEL_HTTPS : LABEL_SSH);
         return panel;
+    }
+
+    protected boolean isHttpUrl(String remoteRepositoryUrl){
+        return remoteRepositoryUrl != null && remoteRepositoryUrl.startsWith("http");
     }
 
     private JRadioButton createRadioButton(final String label, ButtonGroup group) {

--- a/src/main/java/com/smartbear/readyapi/plugin/git/ui/GitRepositorySelectionGui.java
+++ b/src/main/java/com/smartbear/readyapi/plugin/git/ui/GitRepositorySelectionGui.java
@@ -20,7 +20,7 @@ public class GitRepositorySelectionGui extends AbstractRepositorySelectionGui im
 
     @Override
     public Component getComponent() {
-        return createGui(GIT_PLUGIN_WIKI, "Learn about sharing projects with Git");
+        return createGui(GIT_PLUGIN_WIKI, "Learn about sharing projects with Git", gitIntegration.getRemoteRepositoryUrl(project));
     }
 
     @Override

--- a/src/main/java/com/smartbear/readyapi/plugin/git/ui/ImportProjectFromGitGui.java
+++ b/src/main/java/com/smartbear/readyapi/plugin/git/ui/ImportProjectFromGitGui.java
@@ -20,7 +20,7 @@ public class ImportProjectFromGitGui extends AbstractRepositorySelectionGui impl
 
     @Override
     public Component getComponent() {
-        return createGui(GIT_PLUGIN_WIKI, "Learn about importing projects using Git");
+        return createGui(GIT_PLUGIN_WIKI, "Learn about importing projects using Git", null);
     }
 
     @Override


### PR DESCRIPTION
Since this gui can now be show even if a repo is already configured, we populate the repo field if it has been configured.
